### PR TITLE
allow set a initial value on the bit-select component

### DIFF
--- a/projects/bitlogic/src/lib/components/select/select.component.ts
+++ b/projects/bitlogic/src/lib/components/select/select.component.ts
@@ -45,6 +45,12 @@ export class SelectComponent implements OnInit {
   isMultiple: boolean;
 
   @Input()
+  set value(value:any){
+    const selected = this.options.find( option => option.id == value.id);
+    this.selectControl.setValue(selected);
+  };
+
+  @Input()
   selectButtons: SelectButtons = { selectAll: 'Select All', deselectAll: 'Deselect All' };
 
   @Input()


### PR DESCRIPTION
Para los casos que el componente esta en un formulario de edicion, deberia poder iniciar el componente con un valor ya asignado. En este caso se valida por ID.
Lo probe en el ng-ui-kit-demo pero no se como probarlo en un entorno mas confiable.
Tambien es para llevar esta solucion a web-components
![Peek 2022-07-18 14-46](https://user-images.githubusercontent.com/56184847/179571554-c9770522-2636-42e5-8e86-d6388ee44fb5.gif)
